### PR TITLE
Allow PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"require": {
 		"typo3/cms-core": "^10.4 || ^11.5",
 		"typo3/cms-form": "^10.4 || ^11.5",
-		"php": ">= 7.2, < 8.1"
+		"php": ">= 7.2, < 8.2"
 	},
 	"require-dev": {
 		"typo3/testing-framework": "^6.9.0",


### PR DESCRIPTION
The composer.json does not allow PHP 8.1 with the current values in the php requirement. I updated the composer.json file to allow the use of this extension in PHP 8.1 which works perfectly fine for me.