### PR TITLE
Ensure compatibility with php 8.2

### DIFF
--- a/Classes/ViewHelpers/SubstituteLinkViewHelper.php
+++ b/Classes/ViewHelpers/SubstituteLinkViewHelper.php
@@ -31,7 +31,7 @@ class SubstituteLinkViewHelper extends AbstractViewHelper
         /** @var TypolinkCheckbox $element */
         $element = $arguments['element'];
         /** @var string $content */
-        $content = mb_convert_encoding($renderChildrenClosure(), 'HTML-ENTITIES', 'UTF-8');
+        $content = htmlentities($renderChildrenClosure());
 
         $typolink = [
             'parameter' => $element->getProperties()['link'],


### PR DESCRIPTION
Since php 8.2 mb_convert_encoding() with HTML entities is deprecated and will throw an error.